### PR TITLE
Fixed bug for inlineStyles plugin when combining attributes

### DIFF
--- a/plugins/inlineStyles.js
+++ b/plugins/inlineStyles.js
@@ -80,9 +80,6 @@ exports.fn = function(data, opts) {
       var selectedEl = selectedEls[selectedElIndex];
 
       // merge element(inline) styles + matching <style/> styles
-      var elInlineStyleAttr = selectedEl.attr('style'),
-          elInlineStyles    = elInlineStyleAttr.value,
-          inlineCssAst      = csso.parse(elInlineStyles, {context: 'block'});      
 
       var newInlineCssAst   = csso.parse('', {context: 'block'}); // for an empty css ast (in block context)
       csso.walk(selectorItem.rulesetNode, function(node, item) {
@@ -90,11 +87,21 @@ exports.fn = function(data, opts) {
           newInlineCssAst.declarations.insert(item);
         }
       });
-      csso.walk(inlineCssAst, function(node, item) {
-        if(node.type === 'Declaration') {
-          newInlineCssAst.declarations.insert(item);
-        }
-      });
+
+      var elInlineStyleAttr = selectedEl.attr('style');
+      if(elInlineStyleAttr) {
+        var elInlineStyles = elInlineStyleAttr.value,
+            inlineCssAst   = csso.parse(elInlineStyles, {context: 'block'});
+
+        csso.walk(inlineCssAst, function(node, item) {
+            if(node.type === 'Declaration') {
+            newInlineCssAst.declarations.insert(item);
+            }
+        });
+      } else {
+        elInlineStyleAttr = {name:'style', value:'', prefix:'', local:'style' }
+      }
+
       var newCss = csso.translate(newInlineCssAst);
 
       elInlineStyleAttr.value = newCss;

--- a/test/plugins/inlineStyles.08.svg
+++ b/test/plugins/inlineStyles.08.svg
@@ -1,0 +1,12 @@
+<svg id="test" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+    <style>
+        .st0{fill:blue;}
+    </style>
+    <rect width="100" height="100" class="st0"/>
+</svg>
+
+@@@
+
+<svg id="test" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+    <rect width="100" height="100" class="st0" style="fill:blue"/>
+</svg>


### PR DESCRIPTION
There is a case when css properties of a style tag where not added to the corresponding svg element if it has no style tag initially.